### PR TITLE
Populate database with many scores

### DIFF
--- a/lib/mix/tasks/populate_database.ex
+++ b/lib/mix/tasks/populate_database.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.PopulateDatabase do
   use Mix.Task
 
-  @requirement ["app.start"]
+  @requirements ["app.start"]
 
   alias ScoreRandomizer.Data
   alias ScoreRandomizer.Data.Score
@@ -9,24 +9,16 @@ defmodule Mix.Tasks.PopulateDatabase do
 
   @impl Mix.Task
   def run(_args) do
+    entries = Repo.aggregate(Score, :count, :id)
 
-
-    entries_number = Repo.aggregate(Score, :count, :id)
-
-    if entries_number < 1_000_000 do
+    if entries < 100 do
       Mix.shell().info("Seeding the database")
+      result = Data.create_scores_in_bulk(1_000_000)
 
-      now = DateTime.utc_now()
-
-      %{value: 0, insert_at: now, updated_at: now}
-      |> list.duplicate(1_000_000)
-      |> Enum.chunk_every(15_000)
-      |> Enum.each(&Repo.insert_all(Score, &1))
-
+      Mix.shell().info("#{inspect(result, pretty: true)}")
       Mix.shell().info("Seeding completed")
     else
       Mix.shell().info("Database Already Seeded")
     end
-
   end
 end

--- a/lib/score_randomizer/data.ex
+++ b/lib/score_randomizer/data.ex
@@ -4,6 +4,7 @@ defmodule ScoreRandomizer.Data do
   """
 
   import Ecto.Query, warn: false
+  alias Ecto.Multi
   alias ScoreRandomizer.Repo
 
   alias ScoreRandomizer.Data.Score
@@ -71,6 +72,34 @@ defmodule ScoreRandomizer.Data do
     %Score{}
     |> Score.changeset(attrs)
     |> Repo.insert()
+  end
+
+  @doc """
+    Creates scores in Bulk
+
+    ## Exmaples
+    iex> create_scores(2)
+    {:ok, [%Score{}, ...]}
+
+    iex> create_scores_in_bulk(2)
+    {:error, any()}
+  """
+
+  def create_scores_in_bulk(number \\ 10) do
+    1..number
+    |> Enum.chunk_every(15_000)
+    |> Enum.map(&create_scores/1)
+  end
+
+  def create_scores(index_list) do
+    Enum.reduce(index_list, Multi.new(), fn index, multi ->
+      Multi.insert(
+        multi,
+        {:score, index},
+        Score.changeset(%Score{}, %{value: Enum.random(0..100)})
+      )
+    end)
+    |> Repo.transaction()
   end
 
   @doc """

--- a/lib/score_randomizer/data.ex
+++ b/lib/score_randomizer/data.ex
@@ -78,10 +78,10 @@ defmodule ScoreRandomizer.Data do
     Creates scores in Bulk
 
     ## Exmaples
-    iex> create_scores(2)
+    iex> create_scores_in_bulk(1_000)
     {:ok, [%Score{}, ...]}
 
-    iex> create_scores_in_bulk(2)
+    iex> create_scores_in_bulk(1_000)
     {:error, any()}
   """
 
@@ -91,6 +91,16 @@ defmodule ScoreRandomizer.Data do
     |> Enum.map(&create_scores/1)
   end
 
+  @doc """
+    Creates multiple scores by passing a list of integer indexes
+
+    ## Exmaples
+    iex> create_scores(0..10)
+    {:ok, [%Score{}, ...]}
+
+    iex> create_scores_in_bulk(0..10)
+    {:error, any()}
+  """
   def create_scores(index_list) do
     Enum.reduce(index_list, Multi.new(), fn index, multi ->
       Multi.insert(

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule ScoreRandomizer.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "ecto.setup", "assets.setup", "assets.build"],
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run populate_database"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],

--- a/mix/tasks/populate_database.ex
+++ b/mix/tasks/populate_database.ex
@@ -1,0 +1,32 @@
+defmodule Mix.Tasks.PopulateDatabase do
+  use Mix.Task
+
+  @requirement ["app.start"]
+
+  alias ScoreRandomizer.Data
+  alias ScoreRandomizer.Data.Score
+  alias ScoreRandomizer.Repo
+
+  @impl Mix.Task
+  def run(_args) do
+
+
+    entries_number = Repo.aggregate(Score, :count, :id)
+
+    if entries_number < 1_000_000 do
+      Mix.shell().info("Seeding the database")
+
+      now = DateTime.utc_now()
+
+      %{value: 0, insert_at: now, updated_at: now}
+      |> list.duplicate(1_000_000)
+      |> Enum.chunk_every(15_000)
+      |> Enum.each(&Repo.insert_all(Score, &1))
+
+      Mix.shell().info("Seeding completed")
+    else
+      Mix.shell().info("Database Already Seeded")
+    end
+
+  end
+end

--- a/test/score_randomizer/data_test.exs
+++ b/test/score_randomizer/data_test.exs
@@ -33,6 +33,20 @@ defmodule ScoreRandomizer.DataTest do
       assert {:error, %Ecto.Changeset{}} = Data.create_score(%{value: 1002})
     end
 
+    test "create_scores_in_bulk/1 create multiple scores in bulk" do
+      [ok: map] = Data.create_scores_in_bulk(5)
+      assert Map.keys(map) == [{:score, 1}, {:score, 2}, {:score, 3}, {:score, 4}, {:score, 5}]
+    end
+
+    test "create_scores/1 create muliple scores when a list of index is passed" do
+      {:ok, result} = Data.create_scores(1..5)
+
+      Enum.map(result, fn {_key, score} ->
+        assert {:ok, _uuid} = Ecto.UUID.cast(score.id)
+        refute is_nil(score.value)
+      end)
+    end
+
     test "update_score/2 with valid data updates the score" do
       score = score_fixture()
       update_attrs = %{value: 43}


### PR DESCRIPTION
## Description
Create a mixed task to populate the database with a million random scores.

## Changes
* Created multiple functions in the data context to batch-insert data in the database 
* Created mix task 
* Configured `mix ecto.setup` tasks to seed the database using `mix populate_database` task
